### PR TITLE
添加 npm 自动发布工作流

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -61,7 +61,7 @@ jobs:
           else
             echo "version=${ORIGINAL_VERSION}" >> $GITHUB_OUTPUT
           fi
-
+      
       - name: 修改 package.json
         run: |
           # 读取package.json


### PR DESCRIPTION
此 PR 添加了 GitHub Action 工作流，使仓库在代码变更时自动发布到 npm。

要使用此功能，请在仓库 Settings > Secrets > Actions 中添加 NPM_TOKEN 密钥，其值为您的 npm 访问令牌。